### PR TITLE
Remove docker header

### DIFF
--- a/src/main/resources/com/cloudbees/jenkins/plugins/okidocki/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/okidocki/DockerBuildWrapper/config.jelly
@@ -1,5 +1,4 @@
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form">
-    <h1>Docker !</h1>
     <f:nested>
       <f:hetero-radio field="selector" hasHeader="true"
                       descriptors="${descriptor.selectors()}" />


### PR DESCRIPTION
The header get's added to all job configurations just by having the plugin installed.  Not sure if this is just left over from development?
