### PR TITLE
Add path for cat

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
@@ -90,7 +90,7 @@ public class DockerDecoratedLauncher extends Launcher.DecoratedLauncher {
 
             runInContainer.container =
                 docker.runDetached(runInContainer.image, workdir, volumes, environment, userId,
-                        "cat"); // Command expected to hung until killed
+                        "/bin/cat"); // Command expected to hung until killed
 
         } catch (InterruptedException e) {
             throw new RuntimeException("Interrupted");


### PR DESCRIPTION
On Ubuntu images, cat will not be in PATH, I think due to the different
default shell.

Builds fail with:
```
time="2015-04-30T20:39:16Z" level=fatal msg="Error response from daemon: Cannot start container 4008f40f82e55f8f8cabcbeae495697c30437023a42cf6446b7169aef4f23f6f: [8]
System error: exec: \"cat\": executable file not found in $PATH"
FATAL: Failed to run docker image
java.lang.RuntimeException: Failed to run docker image
        at com.cloudbees.javaenkins.plugins.docker_build_env.Docker.runDetached(Docker.java:97)
        at com.cloudbees.jenkins.plugins.docker_build_env.DockerDecoratedLauncher.startBuildContainer(DockerDecoratedLauncher.java:91)
        at com.cloudbees.jenkinss.plugins.docker_build_env.DockerDecoratedLauncher.launch(DockerDecoratedLauncher.java:57)
        at hudson.Launcher$ProcStarter.start(Launcher.java:381)
        at hudson.tasks.CommandInterpreter.perform(CommandInterpreter.java:97)
        at hudson.tasks.CommandInterpreter.perform(CommandInterpreter.java:66)
        at hudson.tasks.BuildStepMonitor$1.perform(BuildStepMonitor.java:20)
        at hudsonudson.model.AbstractBuild$AbstractBuildExecution.perform(AbstractBuild.java:770)
        at hudson.model.Build$BuildExecution.build(Build.java:199)
        at hudson.model.Build$BuildExecution.doRun(Build.java:160)
        at hudson.model.AbstractBuildbstractBuild$AbstractBuildExecution.run(AbstractBuild.java:533)
        at hudson.model.Run.execute(Run.java:1759)
        at hudson.model.FreeStyleBuild.Runn(FreeStyleBuild.java:43)
        at hudson.model.ResourceController.execute(ResourceControlleresourceController.java:89)
        at hudson.model.Executor.run(Executor.java:java240)
```