### PR TITLE
Add wiki URL and update SCM info.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,6 +10,8 @@
   <artifactId>cloudbees-docker-custom-build-environment</artifactId>
   <version>1.2-SNAPSHOT</version>
   <packaging>hpi</packaging>
+  
+  <url>https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Custom+Build+Environment+Plugin</url>
 
   <!-- get every artifact through repo.jenkins-ci.org, which proxies all the artifacts that we need -->
   <repositories>
@@ -27,9 +29,9 @@
   </pluginRepositories>
 
   <scm>
-    <url>https://github.com/jenkinsci/oki-docki-plugin</url>
-    <connection>scm:git:https://github.com/jenkinsci/oki-docki-plugin.git</connection>
-    <developerConnection>scm:git:git@github.com:jenkinsci/oki-docki-plugin.git</developerConnection>
+    <url>https://github.com/jenkinsci/cloudbees-docker-custom-build-environment-plugin</url>
+    <connection>scm:git:https://github.com/jenkinsci/cloudbees-docker-custom-build-environment-plugin.git</connection>
+    <developerConnection>scm:git:git@github.com:jenkinsci/cloudbees-docker-custom-build-environment-plugin.git</developerConnection>
     <tag>HEAD</tag>
   </scm>
 


### PR DESCRIPTION
I'm working on cleaning up the Update Centre — making sure that plugins have valid wiki URLs — and so I've added the new wiki URL to the POM here.

Oki Docki has been renamed, but even although the [wiki page](https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Custom+Build+Environment+Plugin) claims that there has been a `1.2` release using the new artifact ID, that doesn't seem to be correct.

So it would be great if you could merge this, then make a release.  That will allow us to remove `oki-docki` from the Update Centre.