### PR TITLE
Add vagrant configuration to ease testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 target/
 work/
 
+.vagrant/

--- a/src/test/vagrant/ubuntu-trusty64/Vagrantfile
+++ b/src/test/vagrant/ubuntu-trusty64/Vagrantfile
@@ -1,0 +1,49 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure(2) do |config|
+
+  config.vm.box = "ubuntu/trusty64"
+
+  # Create a forwarded port mapping which allows access to a specific port
+  # within the machine from a port on the host machine. In the example below,
+  # accessing "localhost:8080" will access port 80 on the guest machine.
+  # config.vm.network "forwarded_port", guest: 80, host: 8080
+
+  # Create a private network, which allows host-only access to the machine
+  # using a specific IP.
+  # config.vm.network "private_network", ip: "192.168.33.10"
+
+  # Create a public network, which generally matched to bridged network.
+  # Bridged networks make the machine appear as another physical device on
+  # your network.
+  # config.vm.network "public_network"
+
+  # Share an additional folder to the guest VM. The first argument is
+  # the path on the host to the actual folder. The second argument is
+  # the path on the guest to mount the folder. And the optional third
+  # argument is a set of non-required options.
+  # config.vm.synced_folder "../data", "/vagrant_data"
+
+  # Provider-specific configuration so you can fine-tune various
+  # backing providers for Vagrant. These expose provider-specific options.
+  # Example for VirtualBox:
+  #
+  # config.vm.provider "virtualbox" do |vb|
+  #   # Display the VirtualBox GUI when booting the machine
+  #   vb.gui = true
+  #
+  #   # Customize the amount of memory on the VM:
+  #   vb.memory = "1024"
+  # end
+
+  config.vm.provision "shell", inline: <<-SHELL
+    sudo apt-get update
+    sudo apt-get install -y lxc wget bsdtar curl
+    sudo apt-get install -y linux-image-extra-$(uname -r)
+    sudo modprobe aufs
+
+    wget -qO- https://get.docker.com/ | sh
+    sudo apt-get install -y openjdk-7-jre-headless
+  SHELL
+end


### PR DESCRIPTION
Add vagrant configuration (ubuntu trusty 64 + openjdk + docker) to ease testing.

This helps to create an ubuntu/trusty64 slave with docker daemon to test the plugin.