### PR TITLE
Handling context and docker files separately

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
           <version>1.0</version>
           <optional>true</optional>
       </dependency>
+      <dependency>
+          <groupId>org.mortbay.jetty</groupId>
+          <artifactId>jetty-util</artifactId>
+          <version>6.1.26</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -154,9 +154,9 @@ public class DockerBuildWrapper extends BuildWrapper {
 
             Map<String, String> links = new HashMap<String, String>();
 
-            return runInContainer.getDocker().runDetached(runInContainer.image, workdir,
+            return runInContainer.getDocker().runAttached(runInContainer.image, workdir,
                     runInContainer.getVolumesMap(), runInContainer.getPortsMap(), links, environment, userId,
-                    "/bin/cat"); // Command expected to hung until killed
+                    (String)null); // Command expected to hung until killed
 
         } catch (InterruptedException e) {
             throw new RuntimeException("Interrupted");

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
@@ -71,10 +71,14 @@ public class DockerfileImageSelector extends DockerImageSelector {
         String hash = dfPath.getParent().act(new ComputeDockerfileChecksum());
 
         // search for a tagged image with this hash ID
-        if (!docker.hasImage(hash)) {
+        //MR: we don't want to do this check
+        //MR: The docker build will already cheerfully cache each line item int he docker file
+        //MR: but if you use ADD or COPY to bring ina  resource, this check will miss and ignore any
+        //MR: changes to  that file.
+        //if (!docker.hasImage(hash)) {
             listener.getLogger().println("Build Docker image from "+dfAbsPath+" ...");
             docker.buildImage(ctxPath, dfAbsPath, hash);
-        }
+        //}
 
         return hash;
     }

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
@@ -33,18 +33,47 @@ public class DockerfileImageSelector extends DockerImageSelector {
         this.dockerfile = dockerfile;
     }
 
+    private FilePath getDockerFilePath(FilePath ctxPath, Docker docker, AbstractBuild build, TaskListener listener) throws IOException, InterruptedException {
+
+        FilePath dfPath = null;
+
+        if (dockerfile != null) {
+
+            String expandedDockerFile = build.getEnvironment(listener).expand(dockerfile);
+            dfPath = build.getWorkspace().child(expandedDockerFile);
+
+        } else {
+
+            dfPath = ctxPath.child("DockerFile");
+
+        }
+
+        return dfPath;
+    }
+
+    private String getAbsPath(FilePath fp) throws IOException, InterruptedException {
+
+        File f = new File(fp.toURI());
+
+        return f.getAbsolutePath();
+    }
+
     @Override
     public String prepareDockerImage(Docker docker, AbstractBuild build, TaskListener listener) throws IOException, InterruptedException {
 
         String expandedContextPath = build.getEnvironment(listener).expand(contextPath);
-        FilePath filePath = build.getWorkspace().child(expandedContextPath);
+        FilePath ctxPath = build.getWorkspace().child(expandedContextPath);
 
-        String hash = filePath.act(new ComputeDockerfileChecksum());
+        FilePath dfPath = getDockerFilePath(ctxPath, docker, build, listener);
+
+        String dfAbsPath = getAbsPath(dfPath);
+
+        String hash = dfPath.getParent().act(new ComputeDockerfileChecksum());
 
         // search for a tagged image with this hash ID
         if (!docker.hasImage(hash)) {
-            listener.getLogger().println("Build Docker image from "+expandedContextPath+"/Dockerfile ...");
-            docker.buildImage(filePath, dockerfile, hash);
+            listener.getLogger().println("Build Docker image from "+dfAbsPath+" ...");
+            docker.buildImage(ctxPath, dfAbsPath, hash);
         }
 
         return hash;


### PR DESCRIPTION
I noticed that in prepareDockerImage() that it would assume that there was  Dockerfile int he context root, even if I had specified a custom location for the Dockerfile.

Also I was unable to runt he unit tests without adding that dependency to the pom. Looks like the jenkins-ci artifact brings in jetty but not jetty-util which was needed for the test scaffolding.
