### PR TITLE
Added flag to optionally inherit the Jenkins environment

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -162,7 +162,7 @@ public class Docker implements Closeable {
             args.add("--link", link.getKey() + ":" + link.getValue());
         }
         for (Map.Entry<String, String> e : environment.entrySet()) {
-            if ("HOSTNAME".equals(e.getKey())) {
+            if ("HOSTNAME".equals(e.getKey()) || e.getKey().startsWith("BASH_FUNC")) {
                 continue;
             }
             args.add("--env");

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
@@ -41,6 +41,9 @@ THE SOFTWARE.
           <f:entry field="privileged" title="Run in privileged mode">
             <f:checkbox/>
           </f:entry>
+          <f:entry field="inheritedEnvironment" title="Inherit Jenkins environment">
+            <f:checkbox/>
+          </f:entry>
           <f:entry field="verbose" title="Verbose">
             <f:checkbox/>
           </f:entry>

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
@@ -29,7 +29,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
             new DockerBuildWrapper(
                 new PullDockerImageSelector("ubuntu:14.04"),
-                "", new DockerServerEndpoint("", ""), "", true, false, false)
+                "", new DockerServerEndpoint("", ""), "", true, false, false, false)
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 


### PR DESCRIPTION
This change makes it so only the relevant job details are injected into the container. Injecting the entire environment from where Jenkins was running would either clobber the build environment in the build container (e.g. PATH and JAVA_OPTS) or cause an invalid docker command to be constructed. 

Container run command when inheriting environment:

    docker run --tty --detach --user 0:0 --workdir /var/jenkins_home/jobs/container-build/workspace --volume /var/jenkins_home/jobs/container-build/workspace:/var/jenkins_home/jobs/container-build/workspace:rw --volume /tmp:/tmp:rw --env 'BASH_FUNC_copy_reference_file%%=() {  f=${1%/};
     echo "$f" >> /var/jenkins_home/copy_reference_file.log;
     rel=${f:23};
     dir=$(dirname ${f});
     echo " $f -> $rel" >> /var/jenkins_home/copy_reference_file.log;
     if [[ ! -e /var/jenkins_home/${rel} ]]; then
     echo "copy $rel to JENKINS_HOME" >> /var/jenkins_home/copy_reference_file.log;
     mkdir -p /var/jenkins_home/${dir:23};
     cp -r /usr/share/jenkins/ref/${rel} /var/jenkins_home/${rel};
     [[ ${rel} == plugins/*.jpi ]] && touch /var/jenkins_home/${rel}.pinned;
     fi
    }' --env BUILD_DISPLAY_NAME=#23 --env BUILD_ID=23 --env BUILD_NUMBER=23 --env BUILD_TAG=jenkins-container-build-23 --env BUILD_URL=http://vtse-coreos03:8080/job/container-build/23/ --env CA_CERTIFICATES_JAVA_VERSION=20140324 --env CLASSPATH= --env COPY_REFERENCE_FILE_LOG=/var/jenkins_home/copy_reference_file.log --env DOCKER_HOST=unix:///var/run/docker.sock --env DOCKER_OPTS= --env DOCKER_VERSION=1.6.2 --env EXECUTOR_NUMBER=0 --env GIT_BRANCH=origin/master --env GIT_COMMIT=445be46247ff2fdb1d79ba3553431d63b71a27dd --env GIT_PREVIOUS_COMMIT=445be46247ff2fdb1d79ba3553431d63b71a27dd --env GIT_URL=git@github.dev.dealertrack.com:ddcadamb/junk.git --env HOME=/root --env HUDSON_HOME=/var/jenkins_home --env HUDSON_SERVER_COOKIE=983bf8b3876afcb5 --env HUDSON_URL=http://vtse-coreos03:8080/ --env JAVA_DEBIAN_VERSION=8u45-b14-2~bpo8+2 --env JAVA_VERSION=8u45 --env JENKINS_HOME=/var/jenkins_home --env JENKINS_SERVER_COOKIE=983bf8b3876afcb5 --env JENKINS_SHA=59215da16f9f8a781d185dde683c05fcf11450ef --env JENKINS_UC=https://updates.jenkins-ci.org --env JENKINS_URL=http://vtse-coreos03:8080/ --env JENKINS_VERSION=1.609.2 --env JOB_NAME=container-build --env JOB_URL=http://vtse-coreos03:8080/job/container-build/ --env LANG=C.UTF-8 --env NODE_LABELS=master --env NODE_NAME=master --env PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin --env PWD=/ --env SHLVL=0 --env WORKSPACE=/var/jenkins_home/jobs/container-build/workspace repo/maven-build:7 /bin/cat

Container run command without inheriting environment:

    docker run --tty --detach --user 0:0 --workdir /var/jenkins_home/jobs/container-build/workspace --volume /var/jenkins_home/jobs/container-build/workspace:/var/jenkins_home/jobs/container-build/workspace:rw --volume /tmp:/tmp:rw --env BUILD_ID=37 --env BUILD_NUMBER=37 --env BUILD_TAG=jenkins-container-build-37 --env HUDSON_SERVER_COOKIE=983bf8b3876afcb5 --env JENKINS_SERVER_COOKIE=983bf8b3876afcb5 --env JOB_NAME=container-build --env WORKSPACE=/var/jenkins_home/jobs/container-build/workspace repo/maven-build:7 /bin/cat