### PR TITLE
Support bridge 'net' flag.

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -152,7 +152,7 @@ public class Docker implements Closeable {
             throw new RuntimeException("Failed to remove docker container "+container);
     }
 
-    public String runDetached(String image, String workdir, Map<String, String> volumes, Map<Integer, Integer> ports, Map<String, String> links, EnvVars environment, Set sensitiveBuildVariables, String... command) throws IOException, InterruptedException {
+    public String runDetached(String image, String workdir, Map<String, String> volumes, Map<Integer, Integer> ports, Map<String, String> links, EnvVars environment, Set sensitiveBuildVariables, String net, String... command) throws IOException, InterruptedException {
 
         String docker0 = getDocker0Ip(launcher, image);
 
@@ -172,7 +172,15 @@ public class Docker implements Closeable {
         for (Map.Entry<String, String> link : links.entrySet()) {
             args.add("--link", link.getKey() + ":" + link.getValue());
         }
-        args.add("--add-host", "dockerhost:"+docker0);
+
+        if (net.length() > 0) {
+            args.add("--net", net);
+        }
+
+        if (!"host".equals(net)){
+            //--add-host and --net=host are incompatible
+            args.add("--add-host", "dockerhost:"+docker0);
+        }
 
         for (Map.Entry<String, String> e : environment.entrySet()) {
             if ("HOSTNAME".equals(e.getKey())) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -65,11 +65,13 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     private final boolean forcePull;
 
+    private String net;
 
     @DataBoundConstructor
     public DockerBuildWrapper(DockerImageSelector selector, String dockerInstallation, DockerServerEndpoint dockerHost, String dockerRegistryCredentials, boolean verbose, boolean privileged,
                               List<Volume> volumes, String group, String command,
-                              boolean forcePull) {
+                              boolean forcePull,
+                              String net) {
         this.selector = selector;
         this.dockerInstallation = dockerInstallation;
         this.dockerHost = dockerHost;
@@ -80,6 +82,7 @@ public class DockerBuildWrapper extends BuildWrapper {
         this.group = group;
         this.command = command;
         this.forcePull = forcePull;
+        this.net = net;
     }
 
     public DockerImageSelector getSelector() {
@@ -121,6 +124,8 @@ public class DockerBuildWrapper extends BuildWrapper {
     public boolean isForcePull() {
         return forcePull;
     }
+
+    public String getNet() { return net;}
 
     @Override
     public Launcher decorateLauncher(final AbstractBuild build, final Launcher launcher, final BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
@@ -192,7 +197,7 @@ public class DockerBuildWrapper extends BuildWrapper {
 
             return runInContainer.getDocker().runDetached(runInContainer.image, workdir,
                     runInContainer.getVolumes(build), runInContainer.getPortsMap(), links,
-                    environment, build.getSensitiveBuildVariables(),
+                    environment, build.getSensitiveBuildVariables(), net,
                     command.split(" ")); // Command expected to hung until killed
 
         } catch (InterruptedException e) {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
@@ -61,6 +61,9 @@ THE SOFTWARE.
           <f:entry field="command" title="Container start command">
             <f:textbox default="/bin/cat"/>
           </f:entry>
+          <f:entry field="net" title="Network bridge">
+            <f:textbox default="bridge"/>
+          </f:entry>
         </f:advanced>
 
     </f:nested>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-net.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-net.html
@@ -1,0 +1,4 @@
+This advanced option let you configure the network bridge to use for the container.
+You should not change this option until you have some advanced requirements.
+
+See <a href="https://docs.docker.com/articles/networking/#container-networking">container networking</a> documentation for more info.

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
@@ -31,7 +31,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
             new DockerBuildWrapper(
                 new PullDockerImageSelector("ubuntu:14.04"),
-                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false)
+                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge")
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 


### PR DESCRIPTION
Adds support for the 'net' flag with a free text input field.
See https://docs.docker.com/articles/networking/#container-networking.

If --net is defined and equals "host", --add-host is not enabled (the options conflict in Docker command line).