### PR TITLE
[JENKINS-31166] Extra quotes messes up with environment variables content

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -305,7 +305,7 @@ public class Docker implements Closeable {
 
         // Build a list of environment, hidding node's one
         for (Map.Entry<String, String> e : environment.entrySet()) {
-            prefix.add(e.getKey()+"=\""+e.getValue()+'\"');
+            prefix.add(e.getKey()+"="+e.getValue());
         }
 
         starter.cmds().addAll(0, prefix);


### PR DESCRIPTION
https://issues.jenkins-ci.org/browse/JENKINS-31166

@reviewbybees 

Notice how all environment variables are quoted in the report when calling 'env'. I've removed these and checked that it is not causing issues even for values containing spaces.