### PR TITLE
Don't assume the image contains specific binaries

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -219,7 +219,7 @@ public class Docker implements Closeable {
                 .add("run", "--rm")
                 .add("--entrypoint")
                 .add("/bin/true")
-                .add(image);
+                .add("alpine:3.2");
 
         int status = launcher.launch()
                 .envs(getEnvVars())
@@ -245,13 +245,13 @@ public class Docker implements Closeable {
         // Docker daemon might be configured with a custom bridge, or maybe we are just running from Windows/OSX
         // with boot2docker ...
         // alternatively, let's run the specified image once to discover gateway IP from the container
-        // NOTE: we assume here `ip is installed on target image, which is not the case for sample in `ubuntu:15.04`
+        // NOTE: alpine:3.2 has a size of 2MB and contains the `/sbin/ip` binary
 
         args = dockerCommand()
                 .add("run", "--tty", "--rm")
                 .add("--entrypoint")
                 .add("/sbin/ip")
-                .add(image)
+                .add("alpine:3.2")
                 .add("route");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();


### PR DESCRIPTION
Even big/popular images like `ubuntu` don't have the `/sbin/ip` binary by default. To work around assuming the image the user supplied has the required binaries (`/bin/true` and `/sbin/ip`), using a very small but known image like `alpine:3.2` (2MB in size) should be preferred.

If there is anything I have missed or should have done differently, let me know!