### PR TITLE
[JENKINS-29239] Containerized Jenkins via Data Volume Container (--vo…

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/BuiltInContainer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/BuiltInContainer.java
@@ -27,6 +27,7 @@ public class BuiltInContainer implements BuildBadgeAction, EnvironmentContributi
     private final transient Docker docker;
     private List<Integer> ports = new ArrayList<Integer>();
     private Map<String,String> volumes = new HashMap<String,String>();
+    private List<String> dataVolumeContainers = new ArrayList<String>();
 
     public BuiltInContainer(Docker docker) {
         this.docker = docker;
@@ -96,6 +97,14 @@ public class BuiltInContainer implements BuildBadgeAction, EnvironmentContributi
         return volumes;
     }
 
+    public void addDataVolumeContainer(String name) {
+      dataVolumeContainers.add(name);
+    }
+
+    public List<String> getDataVolumeContainers() {
+        return dataVolumeContainers;
+    }
+
 
     public @Nonnull Map<Integer, Integer> getPortsMap() {
         Map<Integer, Integer> map = new HashMap<Integer, Integer>();
@@ -112,5 +121,18 @@ public class BuiltInContainer implements BuildBadgeAction, EnvironmentContributi
             map.put(environment.expand(e.getKey()), environment.expand(e.getValue()));
         }
         return map;
+    }
+
+    public @Nonnull List<String> getDataVolumeContainers(AbstractBuild build) throws IOException, InterruptedException {
+        final EnvVars environment = build.getEnvironment(TaskListener.NULL);
+        List<String> list = new ArrayList<String>(dataVolumeContainers);
+        for (int i = 0; i < list.size(); i++) {
+          String dataVolumeContainer = list.get(i);
+          String dataVolumeContainerExpanded = environment.expand(dataVolumeContainer);
+          if (dataVolumeContainer != dataVolumeContainerExpanded) {
+            list.set(i, dataVolumeContainerExpanded);
+          }
+        }
+        return list;
     }
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DataVolumeContainer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DataVolumeContainer.java
@@ -1,0 +1,29 @@
+package com.cloudbees.jenkins.plugins.docker_build_env;
+
+import hudson.Extension;
+import hudson.model.AbstractDescribableImpl;
+import hudson.model.Descriptor;
+import org.kohsuke.stapler.DataBoundConstructor;
+
+public class DataVolumeContainer extends AbstractDescribableImpl<DataVolumeContainer> {
+
+    private final String name;
+
+    @DataBoundConstructor
+    public DataVolumeContainer(String name) {
+        this.name = name;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    @Extension
+    public static class DescriptorImpl extends Descriptor<DataVolumeContainer> {
+
+        @Override
+        public String getDisplayName() {
+            return "DataVolumeContainer";
+        }
+    }
+}

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -53,9 +53,13 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     private final String dockerRegistryCredentials;
 
+    private final boolean jenkinsMountedInDataVolumeContainer;
+
     private final boolean verbose;
 
     private List<Volume> volumes;
+
+    private List<DataVolumeContainer> dataVolumeContainers;
 
     private final boolean privileged;
 
@@ -68,17 +72,19 @@ public class DockerBuildWrapper extends BuildWrapper {
     private String net;
 
     @DataBoundConstructor
-    public DockerBuildWrapper(DockerImageSelector selector, String dockerInstallation, DockerServerEndpoint dockerHost, String dockerRegistryCredentials, boolean verbose, boolean privileged,
-                              List<Volume> volumes, String group, String command,
+    public DockerBuildWrapper(DockerImageSelector selector, String dockerInstallation, DockerServerEndpoint dockerHost, String dockerRegistryCredentials, boolean jenkinsMountedInDataVolumeContainer, boolean verbose, boolean privileged,
+                              List<Volume> volumes, List<DataVolumeContainer> dataVolumeContainers, String group, String command,
                               boolean forcePull,
                               String net) {
         this.selector = selector;
         this.dockerInstallation = dockerInstallation;
         this.dockerHost = dockerHost;
         this.dockerRegistryCredentials = dockerRegistryCredentials;
+        this.jenkinsMountedInDataVolumeContainer = jenkinsMountedInDataVolumeContainer;
         this.verbose = verbose;
         this.privileged = privileged;
         this.volumes = volumes != null ? volumes : Collections.<Volume>emptyList();
+        this.dataVolumeContainers = dataVolumeContainers != null ? dataVolumeContainers : Collections.<DataVolumeContainer>emptyList();
         this.group = group;
         this.command = command;
         this.forcePull = forcePull;
@@ -101,6 +107,10 @@ public class DockerBuildWrapper extends BuildWrapper {
         return dockerRegistryCredentials;
     }
 
+    public boolean isJenkinsMountedInDataVolumeContainer() {
+      return jenkinsMountedInDataVolumeContainer;
+    }
+
     public boolean isVerbose() {
         return verbose;
     }
@@ -111,6 +121,10 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     public List<Volume> getVolumes() {
         return volumes;
+    }
+
+    public List<DataVolumeContainer> getDataVolumeContainers() {
+        return dataVolumeContainers;
     }
 
     public String getGroup() {
@@ -129,7 +143,7 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     @Override
     public Launcher decorateLauncher(final AbstractBuild build, final Launcher launcher, final BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
-        final Docker docker = new Docker(dockerHost, dockerInstallation, dockerRegistryCredentials, build, launcher, listener, verbose, privileged);
+        final Docker docker = new Docker(dockerHost, dockerInstallation, dockerRegistryCredentials, build, launcher, listener, jenkinsMountedInDataVolumeContainer, verbose, privileged);
 
         final BuiltInContainer runInContainer = new BuiltInContainer(docker);
         build.addAction(runInContainer);
@@ -145,18 +159,24 @@ public class DockerBuildWrapper extends BuildWrapper {
 
         BuiltInContainer runInContainer = build.getAction(BuiltInContainer.class);
 
-        // mount slave root in Docker container so build process can access project workspace, tools, as well as jars copied by maven plugin.
-        final String root = Computer.currentComputer().getNode().getRootPath().getRemote();
-        runInContainer.bindMount(root);
+        if (jenkinsMountedInDataVolumeContainer == false) {
+          // mount slave root in Docker container so build process can access
+          // project workspace, tools, as well as jars copied by maven plugin.
+          final String root = Computer.currentComputer().getNode().getRootPath().getRemote();
+          runInContainer.bindMount(root);
 
-        // mount tmpdir so we can access temporary file created to run shell build steps (and few others)
-        String tmp = build.getWorkspace().act(GetTmpdir);
-        runInContainer.bindMount(tmp);
-
-        // mount ToolIntallers installation directory so installed tools are available inside container
+          // mount tmpdir so we can access temporary file created to run shell
+          // build steps (and few others)
+          String tmp = build.getWorkspace().act(GetTmpdir);
+          runInContainer.bindMount(tmp);
+        }
 
         for (Volume volume : volumes) {
             runInContainer.bindMount(volume.getHostPath(), volume.getPath());
+        }
+
+        for (DataVolumeContainer dataVolumeContainer : dataVolumeContainers) {
+          runInContainer.addDataVolumeContainer(dataVolumeContainer.getName());
         }
 
         runInContainer.getDocker().setupCredentials(build);
@@ -198,7 +218,7 @@ public class DockerBuildWrapper extends BuildWrapper {
             String[] command = this.command.length() > 0 ? this.command.split(" ") : new String[0];
 
             return runInContainer.getDocker().runDetached(runInContainer.image, workdir,
-                    runInContainer.getVolumes(build), runInContainer.getPortsMap(), links,
+                    runInContainer.getVolumes(build), runInContainer.getDataVolumeContainers(build), runInContainer.getPortsMap(), links,
                     environment, build.getSensitiveBuildVariables(), net,
                     command); // Command expected to hung until killed
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DataVolumeContainer/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DataVolumeContainer/config.jelly
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2016 CloudBees Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" >
+    <f:entry field="name" title="Name">
+        <f:textbox/>
+    </f:entry>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
@@ -46,7 +46,20 @@ THE SOFTWARE.
             </f:repeatableProperty>
           </f:entry>
 
-          <f:entry field="forcePull" title="force Pull">
+          <f:entry title="Data Volume Containers" field="dataVolumeContainers">
+            <f:repeatableProperty field="dataVolumeContainers">
+                <f:entry title="">
+                  <div align="right">
+                    <f:repeatableDeleteButton />
+                  </div>
+                </f:entry>
+            </f:repeatableProperty>
+          </f:entry>
+          <f:entry field="jenkinsMountedInDataVolumeContainer" title="Jenkins dirs in Data Volume Container">
+            <f:checkbox/>
+          </f:entry>
+
+          <f:entry field="forcePull" title="Force Pull">
             <f:checkbox/>
           </f:entry>
           <f:entry field="privileged" title="Run in privileged mode">

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-dataVolumeContainers.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-dataVolumeContainers.html
@@ -1,0 +1,17 @@
+Mount volumes from Data Volume Container(s) into the Docker container.
+<p>
+If you have some persistent data that you want to share between containers, or
+want to use from non-persistent containers, it’s best to create a named Data
+Volume Container, and then to mount the data from it.
+<p>
+An example of this is when Jenkins is running in a Docker container and needs to
+share its workspace and '/tmp' dir with the docker-custom-build-environment
+container. To accomplish this, create a Data Volume Container named
+'jenkinsdata' which exposes volumes '/var/jenkins_home' and '/tmp'. Mount these
+volumes in the 'jenkinsmaster' container via `--volumes-from jenkinsdata`. Once
+'jenkinsmaster' is up and running, create a job that uses the
+docker-custom-build-environment plugin and mount the same volumes by specifying
+'jenkinsdata' in the Data Volume Container Name field.
+<p>
+**NOTE** In order for the above example to work, the "Jenkins dirs in Data Volume Container"
+checkbox must also be checked.

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-jenkinsMountedInDataVolumeContainer.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-jenkinsMountedInDataVolumeContainer.html
@@ -1,0 +1,6 @@
+<div>
+    If the Jenkins root & /tmp dirs are mounted in a Data Volume Container,
+    which will be the case if Jenkins itself is runing in a Docker container,
+    then please enable this option to prevent those same directories on the
+    Docker host from also being mounted.
+</div>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-volumes.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-volumes.html
@@ -1,8 +1,7 @@
-Define volumes to bind mound from slave host into container.
+Define volumes to bind mount from slave host into the Docker container.
 <p>
 Typical usage is to bind mount maven local repository to avoid downloading dependencies again and again.
 If your container image does not define a custom user to match the jenkins user used on build executor
 (which is expected) then consider user <code>$HOME</code> to be <code>/</code>
 <p>
     Example : HostPath=<code>$WORKSPACE/maven-repository</code>, Path=<code>/.m2/repository</code>
-

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
@@ -33,7 +33,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
             new DockerBuildWrapper(
                 new PullDockerImageSelector("ubuntu:14.04"),
-                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge")
+                "", new DockerServerEndpoint("", ""), "", false, true, false, Collections.<Volume>emptyList(), Collections.<DataVolumeContainer>emptyList(), null, "cat", false, "bridge")
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 
@@ -52,7 +52,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
                 new DockerBuildWrapper(
                         new DockerfileImageSelector(".", "$WORKSPACE/Dockerfile"),
-                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge")
+                        "", new DockerServerEndpoint("", ""), "", false, true, false, Collections.<Volume>emptyList(), Collections.<DataVolumeContainer>emptyList(), null, "cat", false, "bridge")
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 


### PR DESCRIPTION
…lumes-from)

This patch adds support for Docker Data Volume Containers (https://docs.docker.com/engine/userguide/dockervolumes/#creating-and-mounting-a-data-volume-container) and a "Jenkins dirs in Data Volume Container" checkbox, which, when used together, allows docker-custom-build-environment to be used when Jenkins itself is running in a Docker container.

To fully accomplish this, create a Data Volume Container named 'jenkinsdata' which exposes volumes '/var/jenkins_home' and '/tmp'. Mount these volumes in the 'jenkinsmaster' container via `--volumes-from jenkinsdata`. Once 'jenkinsmaster' is up and running, create a job that uses the docker-custom-build-environment plugin and mount the same volumes by specifying 'jenkinsdata' in the Data Volume Container Name field. To finish, make sure the "Jenkins dirs in Data Volume Container" (which prevents the Jenkins workspace and /tmp dirs from being mounted from the Docker host) checkbox is checked, and you will now be able to successfully run your build from within a Docker container.