### PR TITLE
Don't Cache Environment Variables

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -89,10 +89,7 @@ public class Docker implements Closeable {
     }
 
     private EnvVars getEnvVars() throws IOException, InterruptedException {
-        if (envVars == null) {
-            envVars = new EnvVars(build.getEnvironment(listener)).overrideAll(dockerEnv.env());
-        }
-        return envVars;
+        return new EnvVars(build.getEnvironment(listener)).overrideAll(dockerEnv.env());
     }
 
     public boolean pullImage(String image) throws IOException, InterruptedException {


### PR DESCRIPTION
Allow build steps to use environment variables create by previous build steps

I'm not sure if this resolves part of or all of [JENKINS-29621](https://issues.jenkins-ci.org/browse/JENKINS-29621)
It will at least allow me to write a work around groovy script.