### PR TITLE
Inject same env variables when building container and exec command

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/BuiltInContainer.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/BuiltInContainer.java
@@ -27,6 +27,7 @@ public class BuiltInContainer implements BuildBadgeAction, EnvironmentContributi
     private final transient Docker docker;
     private List<Integer> ports = new ArrayList<Integer>();
     private Map<String,String> volumes = new HashMap<String,String>();
+    private EnvVars envVars;
 
     public BuiltInContainer(Docker docker) {
         this.docker = docker;
@@ -82,6 +83,14 @@ public class BuiltInContainer implements BuildBadgeAction, EnvironmentContributi
         if (enable && container != null) {
             env.put("BUILD_CONTAINER_ID", container);
         }
+    }
+
+    public EnvVars getEnvVars() {
+        return envVars;
+    }
+
+    public void setEnvVars(EnvVars envVars) {
+        this.envVars = envVars;
     }
 
     public void bindMount(String path) {

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -191,6 +191,8 @@ public class DockerBuildWrapper extends BuildWrapper {
         try {
             EnvVars environment = buildContainerEnvironment(build, listener);
 
+            runInContainer.setEnvVars(environment);
+
             String workdir = build.getWorkspace().getRemote();
 
             Map<String, String> links = new HashMap<String, String>();

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
@@ -56,16 +56,9 @@ public class DockerDecoratedLauncher extends Launcher.DecoratedLauncher {
     private EnvVars buildContainerEnvironment() throws IOException, InterruptedException {
 
         if (this.env == null) {
-            this.env = runInContainer.getDocker().getEnv(runInContainer.container, launcher);
+            this.env = runInContainer.getEnvVars();
         }
-        EnvVars environment = new EnvVars(env);
-
-        // Let BuildWrapper customize environment, including PATH
-        for (Environment e : build.getEnvironments()) {
-            e.buildEnvVars(environment);
-        }
-
-        return environment;
+        return new EnvVars(env);
     }
 
 }


### PR DESCRIPTION
Hi

Like it said in https://issues.jenkins-ci.org/browse/JENKINS-32393, the injection of environment variables like JAVA_HOME or PATH in the container making trouble, and are not IMO in the feeling of the container way.
Moreover, I see that you have still changed this when the container start here : https://github.com/jenkinsci/docker-custom-build-environment-plugin/commit/79e47f51a82cb66bdb44bf0c5b03460edc6f0cbd

I think this is the same when executing each command.
This PR do that.

But maybe you will think that add get/set in BuiltInContainer.java is not the right way to do that, so it's the "facility way", I can change this if you have a better implementation in mind (I'm pretty sure of that).