### PR TITLE
[JENKINS-32861] : test if Dockerfile exist where the Workspace is def…

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
@@ -35,7 +35,7 @@ public class DockerfileImageSelector extends DockerImageSelector {
         FilePath filePath = build.getWorkspace().child(expandedContextPath);
 
         File dockerFile = new File(filePath.getRemote(), "Dockerfile");
-        if (!dockerFile.exists()) {
+        if (!filePath.child("Dockerfile").exists()) {
             listener.getLogger().println("Your project is missing a Dockerfile");
             throw new InterruptedException("Your project is missing a Dockerfile");
         }


### PR DESCRIPTION
…ined (slave or master), not only on master

I think the actuel test is a regression introduce by #37, because it doesn't work if the job run on a Jenkins Slave. This test is running only on Master. So it fail every time.