### PR TITLE
Fix to use the EnvInject plugin in the build step

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
@@ -58,12 +58,15 @@ public class DockerDecoratedLauncher extends Launcher.DecoratedLauncher {
         if (this.env == null) {
             this.env = runInContainer.getDocker().getEnv(runInContainer.container, launcher);
         }
+
         EnvVars environment = new EnvVars(env);
 
         // Let BuildWrapper customize environment, including PATH
         for (Environment e : build.getEnvironments()) {
             e.buildEnvVars(environment);
         }
+        
+        environment.overrideAll(build.getEnvironment());
 
         return environment;
     }


### PR DESCRIPTION
I think this isn't the best solution for this issue, because it doesn't isolate the docker and the build. But this works in all of my cases. Maybe this could be an option.