### PR TITLE
launch "docker build" from the correct working directory

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -127,6 +127,7 @@ public class Docker implements Closeable {
         TeeOutputStream teeOutputStream = new TeeOutputStream(logOutputStream, resultOutputStream);
 
         int status = launcher.launch()
+                .pwd(workspace)
                 .envs(getEnvVars())
                 .cmds(args)
                 .stdout(teeOutputStream).stderr(err).join();


### PR DESCRIPTION
At least some versions of docker require that the docker build command is
launched from inside the build context folder.