### PR TITLE
add an option to pause after container startup

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -73,11 +73,14 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     private String cpu;
 
+    private int pauseAfterContainerLaunch = 0;
+
     @DataBoundConstructor
     public DockerBuildWrapper(DockerImageSelector selector, String dockerInstallation, DockerServerEndpoint dockerHost, String dockerRegistryCredentials, boolean verbose, boolean privileged,
                               List<Volume> volumes, String group, String command,
                               boolean forcePull,
-                              String net, String memory, String cpu) {
+                              String net, String memory, String cpu,
+                              boolean isLaunchPause, int pauseAfterContainerLaunch) {
         this.selector = selector;
         this.dockerInstallation = dockerInstallation;
         this.dockerHost = dockerHost;
@@ -91,6 +94,7 @@ public class DockerBuildWrapper extends BuildWrapper {
         this.net = net;
         this.memory = memory;
         this.cpu = cpu;
+        this.pauseAfterContainerLaunch = isLaunchPause ? pauseAfterContainerLaunch : 0;
     }
 
     public DockerImageSelector getSelector() {
@@ -131,6 +135,10 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     public boolean isForcePull() {
         return forcePull;
+    }
+
+    public int getPauseAfterContainerLaunch() {
+        return pauseAfterContainerLaunch;
     }
 
     public String getNet() { return net;}
@@ -184,6 +192,13 @@ public class DockerBuildWrapper extends BuildWrapper {
 
             runInContainer.container = startBuildContainer(runInContainer, build, listener);
             listener.getLogger().println("Docker container " + runInContainer.container + " started to host the build");
+        }
+
+        // pause after container launch if configured
+        if ( pauseAfterContainerLaunch > 0 ) {
+            listener.getLogger().println("Pausing for " + pauseAfterContainerLaunch + " seconds to allow the container to complete startup");
+            try {Thread.sleep(pauseAfterContainerLaunch * 1000);}
+            catch ( InterruptedException ex ) {}
         }
 
         // We are all set, DockerDecoratedLauncher now can wrap launcher commands with docker-exec

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
@@ -70,6 +70,12 @@ THE SOFTWARE.
           <f:entry field="cpu" title="CPU shares">
             <f:textbox/>
           </f:entry>
+          <f:optionalBlock field="isLaunchPause" title="${%Pause after container launch}" checked="${instance.pauseAfterContainerLaunch>0}"
+              help="/descriptor/com.cloudbees.jenkins.plugins.docker_build_env.DockerBuildWrapper/help/launch-pause" inline="true">
+            <f:entry title="${%Pause Seconds}">
+              <f:number clazz="number" field="pauseAfterContainerLaunch" min="0" max="30" step="1" />
+            </f:entry>
+          </f:optionalBlock>
         </f:advanced>
 
     </f:nested>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-launch-pause.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-launch-pause.html
@@ -1,0 +1,3 @@
+For some container setups, it may be desirable to pause briefly after the container has completed startup to allow a startup script to complete prior to launching the first build command.
+<br>
+If enabled, the build will pause for this number of seconds after container startup.

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
@@ -33,7 +33,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
             new DockerBuildWrapper(
                 new PullDockerImageSelector("ubuntu:14.04"),
-                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null)
+                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, false, 0)
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 
@@ -52,7 +52,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
                 new DockerBuildWrapper(
                         new DockerfileImageSelector(".", "$WORKSPACE/Dockerfile"),
-                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null)
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, false, 0)
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 


### PR DESCRIPTION
Some container launch scripts may need a few seconds to complete start
before the build starts executing additional commands.  Allow a user
configured pause before allowing the build to continue.