### PR TITLE
remove unnecessary spam from the docker exec command line

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerDecoratedLauncher.java
@@ -65,6 +65,14 @@ public class DockerDecoratedLauncher extends Launcher.DecoratedLauncher {
             e.buildEnvVars(environment);
         }
 
+        // no need to include variables already defined by docker run
+        // on the command line for each build step
+        for ( String key : env.keySet() ) {
+            if ( env.get(key).equals(environment.get(key)) ) {
+                environment.remove(key);
+            }
+        }
+
         return environment;
     }
 


### PR DESCRIPTION
Variable definitions passed into docker run via --env are also included
in the environment of commands launched via docker exec.  So for every
variable that matches the origin docker run environment, we can exclude
that value from the command line and prevent unnecessary value spam in
the build log as a bonus.