### PR TITLE
Slave in container fix

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,6 +46,12 @@
           <version>1.0</version>
           <optional>true</optional>
       </dependency>
+      <dependency>
+          <groupId>org.jenkins-ci.plugins</groupId>
+          <artifactId>token-macro</artifactId>
+          <version>1.10</version>
+          <optional>true</optional>
+      </dependency>
   </dependencies>
 
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -15,6 +15,7 @@ import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryEndpoint;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.jenkinsci.plugins.docker.commons.credentials.KeyMaterial;
 import org.jenkinsci.plugins.docker.commons.tools.DockerTool;
+import org.w3c.tidy.Out;
 
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
@@ -70,7 +70,13 @@ THE SOFTWARE.
           <f:entry field="cpu" title="CPU shares">
             <f:textbox/>
           </f:entry>
-        </f:advanced>
+          <f:entry field="dockerSlaveJenkinsRoot" title="Docker host's JENKINS_HOME (if slave runs in a container)">
+            <f:textbox/>
+          </f:entry>
+          <f:entry field="dockerSlaveTmpDir" title="Docker host's TMPDIR for the slave (if running in a container)">
+            <f:textbox/>
+        </f:entry>
+      </f:advanced>
 
     </f:nested>
 </j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/html-dockerSlaveJenkinsRoot.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/html-dockerSlaveJenkinsRoot.html
@@ -1,0 +1,10 @@
+<p>
+    Define the path that should be used to volume bind the slave's Jenkins root (<code>JENKINS_HOME</code>).
+</p>
+<p>
+    This is useful if the Jenkins node running the job is itself running inside Docker, and the path to the
+    host directory is different from the volume mount point inside the container.
+</p>
+<p>
+    Example : <code>/var/lib/jenkins_home</code>
+</p>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/html-dockerSlaveTmpDir.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/html-dockerSlaveTmpDir.html
@@ -1,0 +1,14 @@
+Define the path that should be used to volume bind the slave's <code>/tmp</code> directory (as defined by
+the <code>java.io.tmpdir</code> system property).
+<p>
+    This is useful if the Jenkins slave itself is running inside Docker. In order for it to successfully
+    share its <code>/tmp</code> directory with the build container, both must be volume-bound from
+    a directory on the Docker host. This setting specifies the host path of that directory.
+</p>
+<p>
+    Example : <code>/var/lib/jenkins_tmp</code>
+</p>
+<p>
+    Please note that the Jenkins slave running in Docker must also be configured to volume-bind the
+    same temporary directory to its <code>/tmp</code> (or whatever <code>java.io.tmpdir</code> points to).
+</p>

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
@@ -33,7 +33,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
             new DockerBuildWrapper(
                 new PullDockerImageSelector("ubuntu:14.04"),
-                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null)
+                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, "", "")
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 
@@ -52,7 +52,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
                 new DockerBuildWrapper(
                         new DockerfileImageSelector(".", "$WORKSPACE/Dockerfile"),
-                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null)
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, "", "")
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 


### PR DESCRIPTION
Added two advanced options for DockerBuildWrapper:
- dockerSlaveJenkinsRoot (the Docker host directory for `$JENKINS_HOME`)
- dockerSlaveTmpDir (the Docker host directory for `java.os.tmpdir`)

Both options support token-macro expansion, so they can be configured per slave.

This is necessary to make this plugin work for setups where the Jenkins slave running the build runs in a Docker container, and has `$JENKINS_HOME` volume-bound from a host path that is different from the container mount point (which is typically the case).

In addition, a Jenkins slave running inside a container will not be able to share its `/tmp` directory with the build container out of the box. The `dockerSlaveTmpDir` setting can be used to share a persistent volume between the slave and build container.
