### PR TITLE
Use last occurrence of "Successfully built" to find the image id

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -140,7 +140,13 @@ public class Docker implements Closeable {
         {
             throw new RuntimeException("Failed to lookup the docker build ImageID.");
         }
-        String imageId = matcher.group(1);
+
+        // find the last occurrence of "Successfully built"
+        String imageId;
+        do {
+            imageId = matcher.group(matcher.groupCount());
+        } while (matcher.find());
+
         if (imageId.equals("")) {
             throw new RuntimeException("Failed to lookup the docker build ImageID.");
         }


### PR DESCRIPTION
Fixes following problem:

If `docker build` output contains "Successfully built" in stdout of some
layer, that unrelated output will be taken as image id.

Happens with a Dockerfile containing `RUN pip install simplejson`, for
example.
