### PR TITLE
Do not use pseudo-TTY

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -179,7 +179,7 @@ public class Docker implements Closeable {
 
 
         ArgumentListBuilder args = dockerCommand()
-            .add("run", "--detach");
+            .add("run", "--tty", "--detach");
         if (privileged) {
             args.add( "--privileged");
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -179,7 +179,7 @@ public class Docker implements Closeable {
 
 
         ArgumentListBuilder args = dockerCommand()
-            .add("run", "--tty", "--detach");
+            .add("run", "--detach");
         if (privileged) {
             args.add( "--privileged");
         }
@@ -275,7 +275,7 @@ public class Docker implements Closeable {
         // NOTE: alpine:3.2 has a size of 2MB and contains the `/sbin/ip` binary
 
         args = dockerCommand()
-                .add("run", "--tty", "--rm")
+                .add("run", "--rm")
                 .add("--entrypoint")
                 .add("/sbin/ip")
                 .add("alpine:3.2")
@@ -303,7 +303,6 @@ public class Docker implements Closeable {
     public EnvVars getEnv(String container, Launcher launcher) throws IOException, InterruptedException {
         final ArgumentListBuilder args = dockerCommand()
                 .add("exec")
-                .add("--tty")
                 .add(container)
                 .add("env");
 
@@ -329,7 +328,6 @@ public class Docker implements Closeable {
     public void executeIn(String container, String userId, Launcher.ProcStarter starter, EnvVars environment) throws IOException, InterruptedException {
         List<String> prefix = dockerCommandArgs();
         prefix.add("exec");
-        prefix.add("--tty");
         prefix.add("--user");
         prefix.add(userId);
         prefix.add(container);


### PR DESCRIPTION
Hello!

I had a strange behaviour with the Phing plugin failing even though my Phingfile wasn't doing anything, so some debugging shown that I was getting return status 129, but running the command directly inside the container gave me 0.

A bit of Google gave me https://github.com/docker/compose/issues/3379#issuecomment-247222298, so `docker exec` does not return the correct status when running with the `--tty` argument.

I did a bit of testing myself, but I'm not sure if we can remove TTY 100% of the time. For my use case it went well.

Thanks!
