### PR TITLE
Do not fail the build if the container cannot be removed

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -77,7 +77,7 @@ public class Docker implements Closeable {
     public boolean hasImage(String image) throws IOException, InterruptedException {
         ArgumentListBuilder args = dockerCommand()
             .add("inspect", image);
-        
+
         OutputStream out = verbose ? listener.getLogger() : new ByteArrayOutputStream();
         OutputStream err = verbose ? listener.getLogger() : new ByteArrayOutputStream();
 
@@ -98,7 +98,7 @@ public class Docker implements Closeable {
     public boolean pullImage(String image) throws IOException, InterruptedException {
         ArgumentListBuilder args = dockerCommand()
             .add("pull", image);
-        
+
         OutputStream out = verbose ? listener.getLogger() : new ByteArrayOutputStream();
         OutputStream err = verbose ? listener.getLogger() : new ByteArrayOutputStream();
         int status = launcher.launch()
@@ -161,7 +161,6 @@ public class Docker implements Closeable {
                 .stdout(out).stderr(err).quiet(!verbose).join();
         if (status != 0)
             throw new RuntimeException("Failed to stop docker container "+container);
-
         args = new ArgumentListBuilder()
             .add(dockerExecutable)
             .add("rm", "--force", container);
@@ -170,7 +169,7 @@ public class Docker implements Closeable {
                 .cmds(args)
                 .stdout(out).stderr(err).quiet(!verbose).join();
         if (status != 0)
-            throw new RuntimeException("Failed to remove docker container "+container);
+            listener.getLogger().println("Failed to remove docker container "+container);
     }
 
     public String runDetached(String image, String workdir, Map<String, String> volumes, Map<Integer, Integer> ports, Map<String, String> links, EnvVars environment, Set sensitiveBuildVariables, String net, String memory, String cpu, String... command) throws IOException, InterruptedException {
@@ -273,7 +272,6 @@ public class Docker implements Closeable {
         // with boot2docker ...
         // alternatively, let's run the specified image once to discover gateway IP from the container
         // NOTE: alpine:3.2 has a size of 2MB and contains the `/sbin/ip` binary
-
         args = dockerCommand()
                 .add("run", "--tty", "--rm")
                 .add("--entrypoint")


### PR DESCRIPTION
Docker sometimes have trouble removing a killed container. This
happens after the "real" building is completed and should not
not change the build's status.

Instead of throwing a RuntimeException, just log that we failed
cleaning up the container.