### PR TITLE
Label the images and name containers used for a build

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -120,6 +120,9 @@ public class Docker implements Closeable {
         args.add("--file", dockerfile)
             .add(workspace.getRemote());
 
+        args.add("--label", "jenkins-project=" + this.build.getProject().getName());
+        args.add("--label", "jenkins-build-number=" + this.build.getNumber());
+
         OutputStream logOutputStream = listener.getLogger();
         OutputStream err = listener.getLogger();
 
@@ -180,6 +183,8 @@ public class Docker implements Closeable {
 
         ArgumentListBuilder args = dockerCommand()
             .add("run", "--tty", "--detach");
+        args.add("--name", this.build.getProject().getName() + "-" + this.build.getNumber());
+
         if (privileged) {
             args.add( "--privileged");
         }


### PR DESCRIPTION
Over time as the Dockerfiles used for particular projects change, we have orphaned images and containers left on the hosts taking up space. Without searching the build logs, it's impossible to tell which images/containers were used for which build projects.

Below are some results of using these changes in my instance:

    # docker ps
    CONTAINER ID        IMAGE               COMMAND             CREATED             STATUS              PORTS               NAMES
    03071f9970db        5e1c9fd4e7fa        "/bin/cat"          9 minutes ago       Up 9 minutes                            test-project-1027
    20bd17c5ac64        6f27747c5ce5        "/bin/cat"          25 minutes ago      Up 25 minutes                           test-project-1026
    8db39224e4f7        6992448d5ead        "/bin/cat"          40 minutes ago      Up 40 minutes                           test-project-1025

    # docker inspect --format "{{.Id}} {{.RepoTags}} {{ index .Config.Labels \"jenkins-project\" }} {{ index .Config.Labels \"jenkins-build-number\" }}" `docker images -q`
    sha256:5e1c9fd4e7fa38d06541efcded82469a185edf2e71bac56c6c5c1f9e127e9361 [] test-project 1027
