### PR TITLE
[JENKINS-31137] avoid NoClassDefError with optional maven-plugin dependency

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/MavenPluginHelper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/MavenPluginHelper.java
@@ -10,7 +10,7 @@ import java.net.UnknownHostException;
 /**
  * @author <a href="mailto:nicolas.deloof@gmail.com">Nicolas De Loof</a>
  */
-@Extension(ordinal = 99)
+@Extension(ordinal = 99, optional = true)
 public class MavenPluginHelper extends TcpSocketHostLocator {
 
     @Override


### PR DESCRIPTION
- As documented in https://wiki.jenkins.io/display/JENKINS/Dependencies+among+plugins, marking extension with `@Extension(optional = true)` prevents Jenkins from throwing a NoClassDefError error.
- fixes https://issues.jenkins-ci.org/browse/JENKINS-31137