### PR TITLE
Add functional test for capturing built image IDs

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,1 @@
+buildPlugin(platforms: ['linux'])

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -140,7 +140,13 @@ public class Docker implements Closeable {
         {
             throw new RuntimeException("Failed to lookup the docker build ImageID.");
         }
-        String imageId = matcher.group(1);
+
+        // find the last occurrence of "Successfully built"
+        String imageId;
+        do {
+            imageId = matcher.group(matcher.groupCount());
+        } while (matcher.find());
+
         if (imageId.equals("")) {
             throw new RuntimeException("Failed to lookup the docker build ImageID.");
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -109,13 +109,16 @@ public class Docker implements Closeable {
     }
 
 
-    public String buildImage(FilePath workspace, String dockerfile, boolean forcePull) throws IOException, InterruptedException {
+    public String buildImage(FilePath workspace, String dockerfile, boolean forcePull, boolean noCache) throws IOException, InterruptedException {
 
         ArgumentListBuilder args = dockerCommand()
             .add("build");
 
         if (forcePull)
             args.add("--pull");
+
+        if (noCache)
+            args.add("--no-cache");
 
         args.add("--file", dockerfile)
             .add(workspace.getRemote());

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -73,11 +73,13 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     private String cpu;
 
+    private final boolean noCache;
+
     @DataBoundConstructor
     public DockerBuildWrapper(DockerImageSelector selector, String dockerInstallation, DockerServerEndpoint dockerHost, String dockerRegistryCredentials, boolean verbose, boolean privileged,
                               List<Volume> volumes, String group, String command,
                               boolean forcePull,
-                              String net, String memory, String cpu) {
+                              String net, String memory, String cpu, boolean noCache) {
         this.selector = selector;
         this.dockerInstallation = dockerInstallation;
         this.dockerHost = dockerHost;
@@ -91,6 +93,7 @@ public class DockerBuildWrapper extends BuildWrapper {
         this.net = net;
         this.memory = memory;
         this.cpu = cpu;
+        this.noCache = noCache;
     }
 
     public DockerImageSelector getSelector() {
@@ -139,6 +142,10 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     public String getCpu() { return cpu;}
 
+    public boolean isNoCache() {
+        return noCache;
+    }
+
     @Override
     public Launcher decorateLauncher(final AbstractBuild build, final Launcher launcher, final BuildListener listener) throws IOException, InterruptedException, Run.RunnerAbortedException {
         final Docker docker = new Docker(dockerHost, dockerInstallation, dockerRegistryCredentials, build, launcher, listener, verbose, privileged);
@@ -176,7 +183,7 @@ public class DockerBuildWrapper extends BuildWrapper {
         if (runInContainer.container == null) {
             if (runInContainer.image == null) {
                 try {
-                    runInContainer.image = selector.prepareDockerImage(runInContainer.getDocker(), build, listener, forcePull);
+                    runInContainer.image = selector.prepareDockerImage(runInContainer.getDocker(), build, listener, forcePull, noCache);
                 } catch (InterruptedException e) {
                     throw new RuntimeException("Interrupted");
                 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerImageSelector.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerImageSelector.java
@@ -15,7 +15,7 @@ import java.util.Collection;
  */
 public abstract class DockerImageSelector extends AbstractDescribableImpl<DockerImageSelector> implements ExtensionPoint {
 
-    public abstract String prepareDockerImage(Docker docker, AbstractBuild build, TaskListener listener, boolean forcePull) throws IOException, InterruptedException;
+    public abstract String prepareDockerImage(Docker docker, AbstractBuild build, TaskListener listener, boolean forcePull, boolean noCache) throws IOException, InterruptedException;
 
     public abstract Collection<String> getDockerImagesUsedByJob(Job<?, ?> job);
 }

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerfileImageSelector.java
@@ -31,7 +31,7 @@ public class DockerfileImageSelector extends DockerImageSelector {
     }
 
     @Override
-    public String prepareDockerImage(Docker docker, AbstractBuild build, TaskListener listener, boolean forcePull) throws IOException, InterruptedException {
+    public String prepareDockerImage(Docker docker, AbstractBuild build, TaskListener listener, boolean forcePull, boolean noCache) throws IOException, InterruptedException {
 
         String expandedContextPath = build.getEnvironment(listener).expand(contextPath);
         FilePath filePath = build.getWorkspace().child(expandedContextPath);
@@ -43,7 +43,7 @@ public class DockerfileImageSelector extends DockerImageSelector {
         }
 
         listener.getLogger().println("Build Docker image from " + expandedContextPath + "/"+getDockerfile()+" ...");
-        return docker.buildImage(filePath, dockerFile.getRemote(), forcePull);
+        return docker.buildImage(filePath, dockerFile.getRemote(), forcePull, noCache);
     }
 
     @Override

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/PullDockerImageSelector.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/PullDockerImageSelector.java
@@ -24,7 +24,7 @@ public class PullDockerImageSelector extends DockerImageSelector {
     }
 
     @Override
-    public String prepareDockerImage(Docker docker, AbstractBuild build, TaskListener listener, boolean forcePull) throws IOException, InterruptedException {
+    public String prepareDockerImage(Docker docker, AbstractBuild build, TaskListener listener, boolean forcePull, boolean noCache) throws IOException, InterruptedException {
         String expandedImage = build.getEnvironment(listener).expand(image);
         if (forcePull || !docker.hasImage(expandedImage)) {
             listener.getLogger().println("Pull Docker image "+expandedImage+" from repository ...");

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
@@ -33,7 +33,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
             new DockerBuildWrapper(
                 new PullDockerImageSelector("ubuntu:14.04"),
-                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null)
+                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, false)
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 
@@ -47,12 +47,12 @@ public class FunctionalTests {
     @Test
     public void run_inside_built_container() throws Exception {
         FreeStyleProject project = jenkins.createFreeStyleProject();
-        project.setScm(new SingleFileSCM("Dockerfile", IOUtils.toString(getClass().getResourceAsStream("/Dockerfile"), "UTF-8")));
+        project.setScm(new SingleFileSCM("Dockerfile", "FROM ubuntu:14.04"));
 
         project.getBuildWrappersList().add(
                 new DockerBuildWrapper(
-                        new DockerfileImageSelector(".", "$WORKSPACE/Dockerfile"),
-                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null)
+                        new DockerfileImageSelector(".", "Dockerfile"),
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, true)
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 
@@ -60,6 +60,31 @@ public class FunctionalTests {
         jenkins.assertBuildStatus(Result.SUCCESS, build);
         String s = FileUtils.readFileToString(build.getLogFile());
         assertThat(s, containsString("Ubuntu 14.04"));
+        jenkins.buildAndAssertSuccess(project);
+    }
+
+    @Test
+    public void run_inside_built_python_pip_container() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+        String dockerfile = String.join(
+                                        "\n",
+                                        "FROM python:3.6.4-alpine3.4",
+                                        "RUN echo Successfully built THIS_STRING_SHOULD_NOT_BE_CAPTURED_AS_IMAGE_ID",
+                                        "RUN pip install simplejson==3.13.2"
+        );
+        project.setScm(new SingleFileSCM("Dockerfile", dockerfile));
+
+        project.getBuildWrappersList().add(
+                new DockerBuildWrapper(
+                        new DockerfileImageSelector(".", "Dockerfile"),
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, true)
+        );
+        project.getBuildersList().add(new Shell("python -V"));
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        jenkins.assertBuildStatus(Result.SUCCESS, build);
+        String s = FileUtils.readFileToString(build.getLogFile());
+        assertThat(s, containsString("Python 3.6.4"));
         jenkins.buildAndAssertSuccess(project);
     }
 


### PR DESCRIPTION
If `pip install` occurred during image build, the output from pip could cause us to capture an incorrect image ID. See PR #55 for more details.

> If docker build output contains "Successfully built" in stdout of some layer, that unrelated output will be taken as image id.
    
> Happens with a Dockerfile containing RUN pip install simplejson, for example.
    
Also added a noCache option so that the Dockerfile tests run more deterministically. Without it, this new test could fail on the first run but pass on successive runs.