### PR TITLE
Ability to use default working directory within a container

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,14 +85,6 @@
           </loggers>
         </configuration>
       </plugin>
-        <plugin>
-            <groupId>org.apache.maven.plugins</groupId>
-            <artifactId>maven-compiler-plugin</artifactId>
-            <configuration>
-                <source>8</source>
-                <target>8</target>
-            </configuration>
-        </plugin>
     </plugins>
   </build>
 

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,14 @@
           </loggers>
         </configuration>
       </plugin>
+        <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+                <source>8</source>
+                <target>8</target>
+            </configuration>
+        </plugin>
     </plugins>
   </build>
 

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -196,7 +196,11 @@ public class Docker implements Closeable {
         if (privileged) {
             args.add( "--privileged");
         }
-        args.add("--workdir", workdir);
+
+        if(workdir != null) {
+            args.add("--workdir", workdir);
+        }
+
         for (Map.Entry<String, String> volume : volumes.entrySet()) {
             args.add("--volume", volume.getKey() + ":" + volume.getValue() + ":rw" );
         }

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -73,13 +73,15 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     private String cpu;
 
+    private final boolean useJenkinsWorkspace;
+
     private final boolean noCache;
 
     @DataBoundConstructor
     public DockerBuildWrapper(DockerImageSelector selector, String dockerInstallation, DockerServerEndpoint dockerHost, String dockerRegistryCredentials, boolean verbose, boolean privileged,
                               List<Volume> volumes, String group, String command,
                               boolean forcePull,
-                              String net, String memory, String cpu, boolean noCache) {
+                              String net, String memory, String cpu, boolean noCache, boolean useJenkinsWorkspace) {
         this.selector = selector;
         this.dockerInstallation = dockerInstallation;
         this.dockerHost = dockerHost;
@@ -94,6 +96,7 @@ public class DockerBuildWrapper extends BuildWrapper {
         this.memory = memory;
         this.cpu = cpu;
         this.noCache = noCache;
+        this.useJenkinsWorkspace = useJenkinsWorkspace;
     }
 
     public DockerImageSelector getSelector() {
@@ -144,6 +147,10 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     public boolean isNoCache() {
         return noCache;
+    }
+
+    public boolean isUseJenkinsWorkspace() {
+        return useJenkinsWorkspace;
     }
 
     @Override
@@ -210,7 +217,10 @@ public class DockerBuildWrapper extends BuildWrapper {
         try {
             EnvVars environment = buildContainerEnvironment(build, listener);
 
-            String workdir = build.getWorkspace().getRemote();
+            String workdir = null;
+            if(isUseJenkinsWorkspace()) {
+                workdir = build.getWorkspace().getRemote();
+            }
 
             Map<String, String> links = new HashMap<String, String>();
 

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/config.jelly
@@ -70,6 +70,9 @@ THE SOFTWARE.
           <f:entry field="cpu" title="CPU shares">
             <f:textbox/>
           </f:entry>
+          <f:entry field="useJenkinsWorkspace" title="Use Jenkins' workspace inside the container">
+            <f:checkbox default="true"/>
+          </f:entry>
         </f:advanced>
 
     </f:nested>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-useJenkinsWorkspace.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-useJenkinsWorkspace.html
@@ -1,0 +1,3 @@
+If selected, the container working path will be the same as the Jenkins' workspace location, e.g. if
+Jenkins Slave's workspace path is <code>/opt/jenkins/workspace/my-job</code> then this will mount this path inside
+the container at the same path <code>/opt/jenkins/workspace/my-job</code>.

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerEnvironmentTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerEnvironmentTests.java
@@ -1,0 +1,58 @@
+package com.cloudbees.jenkins.plugins.docker_build_env;
+
+import hudson.model.FreeStyleBuild;
+import hudson.model.FreeStyleProject;
+import hudson.model.Result;
+import hudson.tasks.Shell;
+import org.apache.commons.io.FileUtils;
+import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
+import org.junit.Rule;
+import org.junit.Test;
+import org.jvnet.hudson.test.JenkinsRule;
+
+import java.util.Collections;
+
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
+import static org.junit.Assert.assertThat;
+
+public class DockerEnvironmentTests {
+    @Rule  // @ClassRule
+    public JenkinsRule jenkins = new JenkinsRule();
+
+    @Test
+    public void overridesDefaultWorkdirToMatchJenkins() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+
+        project.getBuildWrappersList().add(
+                new DockerBuildWrapper(
+                        new PullDockerImageSelector("ubuntu:14.04"),
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, false, true)
+        );
+        project.getBuildersList().add(new Shell("pwd"));
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        jenkins.assertBuildStatus(Result.SUCCESS, build);
+        String logFile = FileUtils.readFileToString(build.getLogFile());
+        assertThat(logFile, containsString(String.format("--workdir %s", build.getWorkspace().getRemote())));
+        jenkins.buildAndAssertSuccess(project);
+    }
+
+    @Test
+    public void usesDefaultWorkdirectoryWithinTheContainer() throws Exception {
+        FreeStyleProject project = jenkins.createFreeStyleProject();
+
+        project.getBuildWrappersList().add(
+                new DockerBuildWrapper(
+                        new PullDockerImageSelector("ubuntu:14.04"),
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, false, false)
+        );
+        project.getBuildersList().add(new Shell("pwd"));
+
+        FreeStyleBuild build = project.scheduleBuild2(0).get();
+        jenkins.assertBuildStatus(Result.SUCCESS, build);
+        String buildLog = FileUtils.readFileToString(build.getLogFile());
+        assertThat(buildLog, not(containsString("--workdir")));
+        jenkins.buildAndAssertSuccess(project);
+    }
+}

--- a/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
+++ b/src/test/java/com/cloudbees/jenkins/plugins/docker_build_env/FunctionalTests.java
@@ -5,7 +5,6 @@ import hudson.model.FreeStyleProject;
 import hudson.model.Result;
 import hudson.tasks.Shell;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.IOUtils;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.junit.Rule;
 import org.junit.Test;
@@ -33,7 +32,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
             new DockerBuildWrapper(
                 new PullDockerImageSelector("ubuntu:14.04"),
-                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, false)
+                "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, false, true)
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 
@@ -52,7 +51,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
                 new DockerBuildWrapper(
                         new DockerfileImageSelector(".", "Dockerfile"),
-                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, true)
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, true, true)
         );
         project.getBuildersList().add(new Shell("lsb_release  -a"));
 
@@ -77,7 +76,7 @@ public class FunctionalTests {
         project.getBuildWrappersList().add(
                 new DockerBuildWrapper(
                         new DockerfileImageSelector(".", "Dockerfile"),
-                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, true)
+                        "", new DockerServerEndpoint("", ""), "", true, false, Collections.<Volume>emptyList(), null, "cat", false, "bridge", null, null, true, true)
         );
         project.getBuildersList().add(new Shell("python -V"));
 


### PR DESCRIPTION
    This is useful when you have you build your own container and want to execute
    a process that produces the output and you don't necessarily want to
    operate on files from Jenkins' workspace. Our usecase is that we pre-build
    our application tests as a container and want to execute mvn inside of it.
    We don't want to have to specify pom.xml path in the existing mvn command.