### PR TITLE
Add support to configure Initial Image from global configuration

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -265,7 +265,7 @@ public class Docker implements Closeable {
                 .add("run", "--rm")
                 .add("--entrypoint")
                 .add("/bin/true")
-                .add("alpine:3.6");
+                .add(initImage);
 
         int status = launcher.launch()
                 .envs(getEnvVars())
@@ -296,7 +296,7 @@ public class Docker implements Closeable {
                 .add("run", "--tty", "--rm")
                 .add("--entrypoint")
                 .add("/sbin/ip")
-                .add("alpine:3.6")
+                .add(initImage)
                 .add("route");
 
         ByteArrayOutputStream out = new ByteArrayOutputStream();

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -7,6 +7,7 @@ import hudson.model.AbstractBuild;
 import hudson.model.Computer;
 import hudson.model.TaskListener;
 import hudson.util.ArgumentListBuilder;
+import jenkins.model.Jenkins;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.io.output.TeeOutputStream;
 import org.apache.commons.lang.StringUtils;
@@ -254,6 +255,11 @@ public class Docker implements Closeable {
 
         // On some distributions, docker doesn't start docker0 bridge until a container do require it
         // So let's run the container once, running /bin/true so it terminates immediately
+
+        DockerBuildWrapper.DescriptorImpl descriptor = (DockerBuildWrapper.DescriptorImpl)
+                Jenkins.getInstance().getDescriptor(DockerBuildWrapper.class);
+
+        final String initImage = descriptor.getInitImage();
 
         ArgumentListBuilder args = dockerCommand()
                 .add("run", "--rm")

--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper.java
@@ -22,11 +22,13 @@ import hudson.util.ListBoxModel;
 import jenkins.authentication.tokens.api.AuthenticationTokens;
 import jenkins.model.Jenkins;
 import jenkins.security.MasterToSlaveCallable;
+import net.sf.json.JSONObject;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerRegistryToken;
 import org.jenkinsci.plugins.docker.commons.credentials.DockerServerEndpoint;
 import org.kohsuke.stapler.AncestorInPath;
 import org.kohsuke.stapler.DataBoundConstructor;
 import org.kohsuke.stapler.QueryParameter;
+import org.kohsuke.stapler.StaplerRequest;
 
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -258,6 +260,25 @@ public class DockerBuildWrapper extends BuildWrapper {
 
     @Extension
     public static class DescriptorImpl extends BuildWrapperDescriptor {
+
+        private String initImage;
+
+        public DescriptorImpl(){
+            super(DockerBuildWrapper.class);
+            load();
+        }
+
+        @Override
+        public boolean configure(StaplerRequest req, JSONObject json) throws FormException {
+            json = json.getJSONObject("buildInDocker");
+            initImage = json.getString("initImage");
+            save();
+            return super.configure(req,json);
+        }
+
+        public String getInitImage() {
+            return initImage;
+        }
 
         @Override
         public String getDisplayName() {

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/global.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/global.jelly
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+The MIT License
+
+Copyright 2015 CloudBees Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+-->
+<?jelly escape-by-default='true'?>
+<j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:d="/lib/docker/commons" xmlns:c="/lib/credentials">
+      <f:section title="Build In Docker Configuration" name="buildInDocker">
+          <f:entry field="initImage" title="Init image">
+            <f:textbox default="alpine:3.6"/>
+          </f:entry>
+      </f:section>
+</j:jelly>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/global.jelly
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/global.jelly
@@ -24,7 +24,7 @@ THE SOFTWARE.
 -->
 <?jelly escape-by-default='true'?>
 <j:jelly xmlns:j="jelly:core" xmlns:f="/lib/form" xmlns:st="jelly:stapler" xmlns:d="/lib/docker/commons" xmlns:c="/lib/credentials">
-      <f:section title="Build In Docker Configuration" name="buildInDocker">
+      <f:section title="Build In Docker Configuration">
           <f:entry field="initImage" title="Init image">
             <f:textbox default="alpine:3.6"/>
           </f:entry>

--- a/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-initImage.html
+++ b/src/main/resources/com/cloudbees/jenkins/plugins/docker_build_env/DockerBuildWrapper/help-initImage.html
@@ -1,0 +1,4 @@
+<div>
+    This image is used to create two temporary containers to start docker0 bridge and to discover gateway IP from the container.
+    <p> DEFAULT: `alpine:3.6` (since it has a size of 2MB).
+</div>


### PR DESCRIPTION
Hi @jonhermansen,

Recently Docker announced [download rate limit](https://docs.docker.com/docker-hub/download-rate-limit/) on anonymous docker image downloads and `docker-custom-build-environment` plugin internally uses an `alpine 3.6` call it an initial image/initImage (hard coded inside plugin). This image is downloaded for most job runs.

Here is a PR to make this image configurable in `Jenkins Global Configuration` under a new section `Build In Docker Configuration`. This will enable/support configuring the image from local repositories instead of pointing it to docker hub.

**Change log:**
- Added a new section `Build In Docker Configuration` in global configuration.
- Added a new text field `Init Image` to allow the Initial image used by the plugin to be configurable (global.jelly).
- Default the `initImage` to `alpine:3.6`.
- Form validations for new field in configuration.
- Help docs for new field.

**Preview of the changes:**
Configuration preview:
![Screenshot 2020-11-12 033803](https://user-images.githubusercontent.com/47483946/98904433-94f01100-24df-11eb-84e2-34d8e984579e.jpg)
Note: Value defaults to `alpine:3.6`

Form validation:
![Screenshot 2020-11-12 033953](https://user-images.githubusercontent.com/47483946/98904458-a802e100-24df-11eb-866a-c0778a21ec9e.jpg)

~ Prasad.