### PR TITLE
Replace all characters which are not allowed in containers name by underscore

### DIFF
--- a/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
+++ b/src/main/java/com/cloudbees/jenkins/plugins/docker_build_env/Docker.java
@@ -191,7 +191,7 @@ public class Docker implements Closeable {
 
         ArgumentListBuilder args = dockerCommand()
             .add("run", "--tty", "--detach");
-        args.add("--name", this.build.getProject().getName() + "-" + this.build.getNumber());
+        args.add("--name", this.build.getProject().getName().replaceAll("[^a-zA-Z0-9_.-]", "_") + "-" + this.build.getNumber());
 
         if (privileged) {
             args.add( "--privileged");


### PR DESCRIPTION
This PR fixes the container name when the Jenkins build name contains illegal characters (for Docker container names). It's important for instance on matrix job names like `"JAVA=oracle-8,label=optane"`. The illegal characters are replaced by underscores (e.g. `"JAVA_oracle-8_label_optane"`)

- [x] Make sure you are opening from a **topic/feature/bugfix branch** (right side) and not your master branch!
- [x] Ensure that the pull request title represents the desired changelog entry
- [x] Please describe what you did
- [ ] Link to relevant issues in GitHub or Jira
- [ ] Link to relevant pull requests, esp. upstream and downstream changes
- [ ] Ensure you have provided tests - that demonstrates feature works or fixes the issue
